### PR TITLE
feat: add shredder spawn logic

### DIFF
--- a/src/engine/__tests__/ShredderSpawn.test.ts
+++ b/src/engine/__tests__/ShredderSpawn.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+  calculateShredderSpawnProbability,
+  shouldSpawnShredder,
+} from "../entities/Shredder";
+
+// Deterministic PRNG (mulberry32)
+function mulberry32(a: number) {
+  return function () {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+describe("Shredder spawn probability", () => {
+  it("matches spec table", () => {
+    const cases = [
+      { A: 0, P: 0.05 },
+      { A: 10, P: 0.05 },
+      { A: 20, P: 0.07 },
+      { A: 50, P: 0.1 },
+      { A: 100, P: 0.15 },
+    ];
+    for (const { A, P } of cases) {
+      expect(calculateShredderSpawnProbability(A)).toBeCloseTo(P, 5);
+    }
+  });
+
+  it("respects clamp", () => {
+    const prob = calculateShredderSpawnProbability(1000, {
+      clampEnabled: true,
+      maxSpawnProb: 0.25,
+    });
+    expect(prob).toBe(0.25);
+  });
+
+  it("should spawn when random below probability", () => {
+    const result = shouldSpawnShredder(0, 0, 0.01);
+    expect(result).toBe(true);
+  });
+
+  it("should not spawn if existing shredders exceed max concurrent", () => {
+    const result = shouldSpawnShredder(20, 2, 0.0, { maxConcurrent: 2 });
+    expect(result).toBe(false);
+  });
+});
+
+describe("Shredder spawn Monte Carlo", () => {
+  it("approx 7% for A=20", () => {
+    const rng = mulberry32(123);
+    const trials = 10000;
+    let count = 0;
+    for (let i = 0; i < trials; i++) {
+      if (shouldSpawnShredder(20, 0, rng())) count++;
+    }
+    const observed = count / trials;
+    expect(observed).toBeGreaterThan(0.06);
+    expect(observed).toBeLessThan(0.08);
+  });
+});

--- a/src/engine/entities/Shredder.ts
+++ b/src/engine/entities/Shredder.ts
@@ -1,0 +1,52 @@
+export interface ShredderSpawnConfig {
+  clampEnabled?: boolean;
+  maxSpawnProb?: number;
+  maxConcurrent?: number;
+}
+
+/**
+ * Calculate spawn probability for Shredder enemy based on number of asteroids on screen.
+ * Implements piecewise rule:
+ *   if A <= 10 -> 5%
+ *   else -> 5% + (A / 1000)
+ * Optional clamp to maxSpawnProb when clampEnabled.
+ */
+export function calculateShredderSpawnProbability(
+  asteroidsOnScreen: number,
+  config: ShredderSpawnConfig = {},
+): number {
+  const A = Math.max(0, asteroidsOnScreen);
+  let probability = A <= 10 ? 0.05 : 0.05 + A / 1000;
+  if (config.clampEnabled) {
+    const max = config.maxSpawnProb ?? 0.25;
+    probability = Math.min(probability, max);
+  }
+  return probability;
+}
+
+/**
+ * Decide if a shredder should spawn this tick.
+ * @param asteroidsOnScreen current asteroid count
+ * @param currentShredders currently active shredders
+ * @param random random value [0,1)
+ * @param config configuration options
+ */
+export function shouldSpawnShredder(
+  asteroidsOnScreen: number,
+  currentShredders: number,
+  random: number,
+  config: ShredderSpawnConfig = {},
+): boolean {
+  const maxConcurrent = config.maxConcurrent ?? 2;
+  if (currentShredders >= maxConcurrent) return false;
+  const probability = calculateShredderSpawnProbability(
+    asteroidsOnScreen,
+    config,
+  );
+  return random < probability;
+}
+
+// Placeholder class for future implementation of full Shredder entity.
+export class Shredder {
+  // Actual rendering and behavior to be implemented separately.
+}


### PR DESCRIPTION
## Summary
- add Shredder spawn probability helper with concurrency and clamp options
- cover Shredder spawn math with deterministic Monte Carlo tests

## Testing
- `npm test src/engine/__tests__/ShredderSpawn.test.ts`
- `npm test` *(fails: Playwright and other suites error in this environment)*
- `npm run lint`
- `npm run format` *(fails: scripts/ai-powered-testing.js syntax error)*

------
https://chatgpt.com/codex/tasks/task_b_68a08a587a2c83248f30abf15430d3c6