### PR TITLE
feat: add shredder enemy

### DIFF
--- a/documentation/SHREDDER_ENEMY.md
+++ b/documentation/SHREDDER_ENEMY.md
@@ -1,0 +1,202 @@
+# Ticket: "Shredder" tri-shuriken enemy (punishes asteroid spam)
+
+## Summary
+
+Add a special enemy **Shredder** (tri-shuriken outline). It’s **bigger than normal ships** (random up to **3×**), **spins** around its axis, and flies a **waveform path** (sine/cosine or gentle lissajous).
+Asteroid interactions:
+
+* **Asteroid smaller than Shredder** → asteroid is **instantly shredded** (laser-hit equivalent).
+* **Asteroid equal or larger** → **Shredder explodes**; asteroid survives (optional partial impact damage).
+
+---
+
+## Correct spawn rule
+
+Let `A = asteroidsOnScreen`.
+
+**Piecewise as spec (“> 10” unlocks the boost):**
+
+```
+if A ≤ 10:  P = 0.05                // 5%
+if A > 10:  P = 0.05 + (A/10)%      // == 0.05 + A/1000
+```
+
+**Examples (per spawn check):**
+
+* A=0  → **5%**  (0.05)
+* A=10 → **5%**  (0.05)
+* A=20 → **7%**  (0.07) ✅
+* A=50 → **10%** (0.10)
+* A=100 → **15%** (0.15)
+
+*(Optional)* clamp extreme cases: `P_max = 0.25` (25%).
+
+**Cadence:** use the existing enemy spawn tick.
+**Concurrency:** `maxConcurrentShredders = 2` (config).
+
+---
+
+## Behavior
+
+* **Scale:** `s ∈ [1.25, 3.0] × normalShipTipRadius`.
+* **Spin:** `ω_spin ∈ [0.6, 1.6] rad/s`, random sign.
+* **Path (choose at spawn):**
+
+  * `SINE`: `y = y0 + A·sin(ωt + φ)`
+  * `COSINE`: `y = y0 + A·cos(ωt + φ)`
+  * `LISSAJOUS-lite`: forward drift + mild 1:2 x/y wobble
+* **Amplitude:** `A ∈ [0.15, 0.30] × screenHeight`.
+* **SpeedX:** reuse normal enemy base speed (± \~20% jitter).
+* **Collisions (use radii):** `rS = shredder.radius`, `rA = asteroid.radius`, tolerance `τ = 0.05`.
+
+  * if `rA < rS·(1−τ)` → shred asteroid (instant kill, sparks FX, small score).
+  * if `rA > rS·(1+τ)` → Shredder explodes (asteroid persists; optional impact damage).
+  * else (≈equal) → both destroyed.
+
+---
+
+## Inline assets (no attachments)
+
+### A) SVG (outline-only)
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-122 -122 244 244" width="244" height="244">
+  <!-- outer outline -->
+  <polyline points="-39.0,67.5 0.0,110.0 39.0,67.5 39.0,-67.5 0.0,-110.0 -39.0,-67.5 -97.5,0.0 -90.4,15.6 -78.4,27.6 -67.5,39.0 -39.0,67.5"
+            fill="none" stroke="#000" stroke-width="2" stroke-linejoin="miter" stroke-linecap="square"/>
+  <!-- inner hub (triangle) -->
+  <polyline points="0.0,18.0 15.6,-9.0 -15.6,-9.0 0.0,18.0"
+            fill="none" stroke="#000" stroke-width="2" stroke-linejoin="miter" stroke-linecap="square"/>
+</svg>
+```
+
+*Note:* This SVG’s coordinates are based on a tip radius of **110** units. The normalized points below divide by 110, so the **furthest tip = 1.0**.
+
+### B) Normalized vector points (furthest tip = 1.0)
+
+```js
+// OUTER polyline (closed by repeating the first point at the end)
+const OUTER = [
+  [-0.3545,  0.6136], [ 0.0000,  1.0000], [ 0.3545,  0.6136],
+  [ 0.3545, -0.6136], [ 0.0000, -1.0000], [-0.3545, -0.6136],
+  [-0.8864,  0.0000], [-0.8218,  0.1418], [-0.7127,  0.2509],
+  [-0.6136,  0.3545], [-0.3545,  0.6136]
+];
+
+// HUB triangle (closed by repeating the first point)
+const HUB = [
+  [ 0.0000,  0.1636], [ 0.1418, -0.0818],
+  [-0.1418, -0.0818], [ 0.0000,  0.1636]
+];
+```
+
+✔️ Checks: `67.5/110=0.6136`, `39/110=0.3545`, `97.5/110=0.8864`, `18/110=0.1636`, `15.6/110=0.1418`, `9/110=0.0818`.
+
+---
+
+## Pseudocode only (framework-agnostic)
+
+> Replace identifiers/types with your engine’s. This is **dummy code** to express intent — **not** drop-in.
+
+### Spawner (called on your existing spawn tick)
+
+```
+function maybeSpawnShredder(world):
+    A = world.countOnscreen("asteroid")
+    if A <= 10:
+        P = 0.05                       // 5%
+    else:
+        P = 0.05 + (A / 1000)          // 5% + (A/10)%
+
+    if CONFIG.clampEnabled:
+        P = min(P, CONFIG.maxSpawnProb)    // e.g., 0.25
+
+    if world.countOnscreen("Shredder") >= CONFIG.maxConcurrent:
+        return
+
+    if random() < P:
+        side = randomChoice("left","right")
+        world.spawn( Shredder(side) )
+```
+
+### Shredder entity (reuses base enemy lifecycle)
+
+```
+class Shredder extends EnemyBase:
+    init(spawnSide):
+        scale = rand(1.25, 3.0)
+        tipRadius = NORMAL_SHIP_TIP_RADIUS * scale
+        rotationSpeed = rand(0.6, 1.6) * randomSign()
+
+        // choose motion
+        motionType = randomChoice(SINE, COSINE, LISSAJOUS_LITE)
+        amplitude = rand(0.15, 0.30) * SCREEN_H
+        omega = rand(0.6, 1.2)
+        phase = rand(0, 2π)
+        forwardSpeedX = BASE_ENEMY_SPEED_X * rand(0.9, 1.2)
+        setStartPositionBySide(spawnSide)
+
+    update(dt):
+        // forward drift + waveform
+        t += dt
+        if motionType == SINE:
+            x = x0 + dir * forwardSpeedX * t
+            y = y0 + amplitude * sin(omega * t + phase)
+        else if motionType == COSINE:
+            x = x0 + dir * forwardSpeedX * t
+            y = y0 + amplitude * cos(omega * t + phase)
+        else: // LISSAJOUS_LITE
+            x = x0 + dir * forwardSpeedX * t + 0.30*SCREEN_W * sin(1*omega*t + phase)
+            y = y0 + amplitude *        sin(2*omega*t + 0.5*phase)
+
+        rotation += rotationSpeed * dt
+        applyCommonEnemyLifetimeCulling()
+
+    render(renderer):
+        // Outline look; if your engine is sprite/mesh-based, draw equivalent
+        renderer.drawTriShurikenOutline(position, tipRadius, rotation,
+                                        strokeWidth = max(1.5, tipRadius * 0.03))
+
+    onCollision(other):
+        if other.type != "asteroid":
+            return handleWithBaseEnemyRules(other)
+
+        rS = tipRadius
+        rA = other.radius
+        τ  = 0.05   // 5% tolerance
+
+        if rA < rS * (1 - τ):
+            other.destroyAsLaserHit()
+            fx("shred_sparks", other.pos)
+            score.add(+10)
+        else if rA > rS * (1 + τ):
+            other.applyImpactDamage(frac = 0.35)   // optional
+            self.explode()
+            fx("metal_burst", self.pos)
+        else:
+            other.destroy()
+            self.explode()
+```
+
+---
+
+## Acceptance criteria
+
+* **Math:** For `A=20`, per-check probability is **7%** (0.07). For `A=50`, **10%**. For `A=100`, **15%**.
+* **Spawn system:** Uses existing spawn cadence; never exceeds `maxConcurrentShredders`.
+* **Movement:** Clear sine/cosine/lissajous-lite motion; amplitude in **15–30%** of screen height.
+* **Visuals:** Outline tri-shuriken scales **1.25×–3×**; crisp miter joins; continuous rotation.
+* **Collisions:** Smaller asteroid shredded; larger asteroid destroys Shredder; near-equal → both destroyed.
+* **DRY:** Reuse base enemy lifecycle (pooling, culling, explosion, scoring hooks).
+
+---
+
+## Test plan
+
+1. **Probability table:** A={0,10,20,50,100} → P={0.05, 0.05, 0.07, 0.10, 0.15}.
+2. **Monte-Carlo sanity:** simulate 10k spawn ticks at A=20 → observed spawn ≈ 7% ± noise.
+3. **Motion & spin:** logs show amplitude within 0.15–0.30H; rotation speed within range and random sign.
+4. **Collision branches:** verify small, large, near-equal outcomes and correct FX/score hooks.
+5. **Concurrency:** never exceed `maxConcurrentShredders` even under A=200 (stress).
+
+---

--- a/src/engine/CentralConfig.ts
+++ b/src/engine/CentralConfig.ts
@@ -49,6 +49,12 @@ export const ENTITY_LIMITS = {
     MIN_COUNT: 0,
     WARNING_THRESHOLD: 80,
   },
+  SHREDDERS: {
+    MAX_TOTAL: 2,
+    MAX_PER_FRAME: 2,
+    MIN_COUNT: 0,
+    WARNING_THRESHOLD: 2,
+  },
   PARTICLES: {
     MAX_TOTAL: 1000,
     MAX_PER_EXPLOSION: 50,
@@ -314,6 +320,33 @@ export const ASTEROID_GEN = {
 } as const;
 
 // ============================================
+// SHREDDER ENEMY CONFIGURATION
+// ============================================
+
+export const SHREDDER = {
+  SPAWN: {
+    BASE_PROBABILITY: 0.05,
+    EXTRA_PER_ASTEROID: 0.001,
+    MAX_PROBABILITY: 0.25,
+  },
+  MAX_CONCURRENT: 2,
+  SCALE: {
+    MIN: 1.25,
+    MAX: 3.0,
+  },
+  SPIN: {
+    MIN: 0.6,
+    MAX: 1.6,
+  },
+  AMPLITUDE: {
+    MIN: 0.15,
+    MAX: 0.30,
+  },
+  SPEED_JITTER: 0.2,
+  TOLERANCE: 0.05,
+} as const;
+
+// ============================================
 // UI CONSTANTS
 // ============================================
 
@@ -495,6 +528,7 @@ export default {
   WAVES,
   COLLISION,
   ASTEROID_GEN,
+  SHREDDER,
   UI,
   ERRORS,
   GameState,

--- a/src/engine/NeonFlockEngine.ts
+++ b/src/engine/NeonFlockEngine.ts
@@ -4,6 +4,7 @@ import { BossBird } from './entities/BossBird';
 import type { BirdProjectile } from './entities/BirdProjectile';
 import { EnergyDot } from './entities/EnergyDot';
 import { Asteroid } from './entities/Asteroid';
+import { Shredder, calculateShredderSpawnProbability } from './entities/Shredder';
 import { AsteroidSplitter } from './systems/AsteroidSplitter';
 import { ParticleSystem } from './systems/ParticleSystem';
 import { FlockingSystem } from './systems/FlockingSystem';
@@ -18,7 +19,7 @@ import CentralConfig from './CentralConfig';
 import { scoringSystem, ScoringEvent } from './ScoringSystem';
 import { hueToRGB } from './utils/ColorUtils';
 
-const { VISUALS, SIZES, TIMING, ENTITY_LIMITS, PHYSICS, FLOCKING, ERRORS, UI, GAME_CONSTANTS } = CentralConfig;
+const { VISUALS, SIZES, TIMING, ENTITY_LIMITS, PHYSICS, FLOCKING, ERRORS, UI, GAME_CONSTANTS, SHREDDER } = CentralConfig;
 
 export class NeonFlockEngine {
   private app!: PIXI.Application;
@@ -29,6 +30,7 @@ export class NeonFlockEngine {
   private projectiles: BirdProjectile[] = [];
   private energyDots: EnergyDot[] = [];
   private asteroids: Asteroid[] = [];
+  private shredders: Shredder[] = [];
   private fallingDots: Array<{
     x: number;
     y: number;
@@ -443,6 +445,17 @@ export class NeonFlockEngine {
       console.error('[SPAWN ERROR] Failed to spawn bird:', error);
     }
   }
+
+  private maybeSpawnShredder() {
+    const A = this.asteroids.length;
+    const P = calculateShredderSpawnProbability(A);
+    if (this.shredders.length >= SHREDDER.MAX_CONCURRENT) return;
+    if (Math.random() < P) {
+      const side = Math.random() < 0.5 ? 'left' : 'right';
+      const shredder = new Shredder(this.app, side);
+      this.shredders.push(shredder);
+    }
+  }
   
   public launchAsteroid(
     startX: number, 
@@ -511,7 +524,7 @@ export class NeonFlockEngine {
     
     // EMERGENCY ENTITY COUNT PROTECTION - Prevent performance freeze with too many entities
     const MAX_TOTAL_ENTITIES = ENTITY_LIMITS.TOTAL_ENTITIES.MAX;
-    const totalEntityCount = this.boids.length + this.asteroids.length + this.fallingDots.length;
+    const totalEntityCount = this.boids.length + this.asteroids.length + this.fallingDots.length + this.shredders.length;
     
     if (totalEntityCount > MAX_TOTAL_ENTITIES) {
       console.warn(`[PERFORMANCE WARNING] Too many entities (${totalEntityCount}/${MAX_TOTAL_ENTITIES}), performing emergency cleanup`);
@@ -572,10 +585,13 @@ export class NeonFlockEngine {
     const dt = delta / 60; // Convert to seconds at 60fps
     const time = performance.now() / 1000;
     
-    // Spawn birds
-    if (this.birdsToSpawn > 0 && time > this.nextSpawnTime) {
-      this.spawnBird();
-      this.birdsToSpawn--;
+    // Spawn birds and maybe Shredder on spawn tick
+    if (time > this.nextSpawnTime) {
+      if (this.birdsToSpawn > 0) {
+        this.spawnBird();
+        this.birdsToSpawn--;
+      }
+      this.maybeSpawnShredder();
       this.nextSpawnTime = time + 0.5;
     }
     
@@ -856,6 +872,45 @@ export class NeonFlockEngine {
       if (!keepAsteroid || asteroid.isOffScreen(this.app.screen)) {
         asteroid.destroy();
         return false;
+      }
+      return true;
+    });
+
+    // Update shredders and handle collisions with asteroids
+    this.shredders = this.shredders.filter(shredder => {
+      const keep = shredder.update(dt);
+      if (!keep) {
+        shredder.destroy();
+        return false;
+      }
+      for (let i = this.asteroids.length - 1; i >= 0; i--) {
+        const asteroid = this.asteroids[i];
+        const dx = asteroid.x - shredder.x;
+        const dy = asteroid.y - shredder.y;
+        const distSq = dx * dx + dy * dy;
+        const threshold = (asteroid.size + shredder.radius) * (asteroid.size + shredder.radius);
+        if (distSq < threshold) {
+          const rS = shredder.radius;
+          const rA = asteroid.size;
+          const tau = SHREDDER.TOLERANCE;
+          if (rA < rS * (1 - tau)) {
+            asteroid.destroy();
+            this.asteroids.splice(i, 1);
+            this.particleSystem.createExplosion(asteroid.x, asteroid.y, 0xFFFFFF, 10);
+            scoringSystem.addEvent(ScoringEvent.SHREDDER_SHRED);
+            this.updateScoreDisplay();
+          } else if (rA > rS * (1 + tau)) {
+            shredder.destroy();
+            this.particleSystem.createExplosion(shredder.x, shredder.y, 0xFFFFFF, 20);
+            return false;
+          } else {
+            asteroid.destroy();
+            this.asteroids.splice(i, 1);
+            shredder.destroy();
+            this.particleSystem.createExplosion(shredder.x, shredder.y, 0xFFFFFF, 20);
+            return false;
+          }
+        }
       }
       return true;
     });

--- a/src/engine/ScoringSystem.ts
+++ b/src/engine/ScoringSystem.ts
@@ -29,6 +29,7 @@ export enum ScoringEvent {
   ASTEROID_SPLIT = 'ASTEROID_SPLIT',
   WAVE_COMPLETE = 'WAVE_COMPLETE',
   PERFECT_WAVE = 'PERFECT_WAVE',
+  SHREDDER_SHRED = 'SHREDDER_SHRED',
   
   // COMBO EVENTS
   COMBO_2X = 'COMBO_2X',
@@ -71,6 +72,7 @@ export const POINT_VALUES = {
     ENERGY_DOT_RECLAIMED: 80,     // Getting stolen dot back
     ENERGY_DOT_CAUGHT_FALLING: 40, // Catching falling dot
     ASTEROID_SPLIT: 5,            // When asteroid splits
+    SHREDDER_SHRED: 10,           // Small asteroid destroyed by Shredder
     WAVE_COMPLETE: 100,           // Completing a wave
     PERFECT_WAVE: 200,            // No dots lost in wave
   },
@@ -280,6 +282,11 @@ export class ScoringSystem {
         
       case ScoringEvent.ENERGY_DOT_CAUGHT_FALLING:
         points = POINT_VALUES.REWARDS.ENERGY_DOT_CAUGHT_FALLING;
+        this.incrementCombo();
+        break;
+
+      case ScoringEvent.SHREDDER_SHRED:
+        points = POINT_VALUES.REWARDS.SHREDDER_SHRED;
         this.incrementCombo();
         break;
         

--- a/src/engine/__tests__/ShredderSpawn.test.ts
+++ b/src/engine/__tests__/ShredderSpawn.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { calculateShredderSpawnProbability } from '../entities/Shredder';
+
+describe('SHREDDER SPAWN PROBABILITY', () => {
+  it('matches table values', () => {
+    const cases: Array<[number, number]> = [
+      [0, 0.05],
+      [10, 0.05],
+      [20, 0.07],
+      [50, 0.10],
+      [100, 0.15],
+    ];
+    for (const [A, expected] of cases) {
+      expect(calculateShredderSpawnProbability(A)).toBeCloseTo(expected);
+    }
+  });
+
+  it('Monte Carlo sanity at A=20', () => {
+    const A = 20;
+    const P = calculateShredderSpawnProbability(A);
+    let spawns = 0;
+    const trials = 10000;
+    for (let i = 0; i < trials; i++) {
+      if (Math.random() < P) spawns++;
+    }
+    const rate = spawns / trials;
+    console.log(`Monte Carlo spawn rate: ${rate}`);
+    expect(rate).toBeGreaterThan(0.05);
+    expect(rate).toBeLessThan(0.09);
+  });
+});

--- a/src/engine/entities/Shredder.ts
+++ b/src/engine/entities/Shredder.ts
@@ -1,0 +1,120 @@
+import * as PIXI from 'pixi.js';
+import CentralConfig from '../CentralConfig';
+import { GameConfig } from '../GameConfig';
+import { EntityDestroyer } from '../utils/EntityDestroyer';
+
+const { SHREDDER, SIZES, VISUALS } = CentralConfig;
+
+export type ShredderPath = 'SINE' | 'COSINE' | 'LISSAJOUS';
+
+export function calculateShredderSpawnProbability(A: number): number {
+  let P = A <= 10 ? SHREDDER.SPAWN.BASE_PROBABILITY : SHREDDER.SPAWN.BASE_PROBABILITY + A * SHREDDER.SPAWN.EXTRA_PER_ASTEROID;
+  if (SHREDDER.SPAWN.MAX_PROBABILITY !== undefined) {
+    P = Math.min(P, SHREDDER.SPAWN.MAX_PROBABILITY);
+  }
+  return P;
+}
+
+const OUTER = [
+  [-0.3545, 0.6136], [0.0, 1.0], [0.3545, 0.6136],
+  [0.3545, -0.6136], [0.0, -1.0], [-0.3545, -0.6136],
+  [-0.8864, 0.0], [-0.8218, 0.1418], [-0.7127, 0.2509],
+  [-0.6136, 0.3545], [-0.3545, 0.6136]
+];
+
+const HUB = [
+  [0.0, 0.1636], [0.1418, -0.0818],
+  [-0.1418, -0.0818], [0.0, 0.1636]
+];
+
+export class Shredder {
+  public x: number;
+  public y: number;
+  public radius: number;
+  public destroyed = false;
+
+  private sprite: PIXI.Graphics;
+  private rotation = 0;
+  private rotationSpeed: number;
+  private direction: number;
+  private t = 0;
+  private app: PIXI.Application;
+  private motionType: ShredderPath;
+  private amplitude: number;
+  private omega: number;
+  private phase: number;
+  private startX: number;
+  private startY: number;
+  private forwardSpeed: number;
+
+  constructor(app: PIXI.Application, spawnSide: 'left' | 'right') {
+    this.app = app;
+    const scale = SHREDDER.SCALE.MIN + Math.random() * (SHREDDER.SCALE.MAX - SHREDDER.SCALE.MIN);
+    const baseTip = SIZES.BIRD.BASE * SIZES.BIRD.TRIANGLE_FRONT_MULTIPLIER;
+    this.radius = baseTip * scale;
+
+    this.rotationSpeed = (SHREDDER.SPIN.MIN + Math.random() * (SHREDDER.SPIN.MAX - SHREDDER.SPIN.MIN)) * (Math.random() < 0.5 ? -1 : 1);
+
+    const motionTypes: ShredderPath[] = ['SINE', 'COSINE', 'LISSAJOUS'];
+    this.motionType = motionTypes[Math.floor(Math.random() * motionTypes.length)];
+    this.amplitude = (SHREDDER.AMPLITUDE.MIN + Math.random() * (SHREDDER.AMPLITUDE.MAX - SHREDDER.AMPLITUDE.MIN)) * app.screen.height;
+    this.omega = 0.6 + Math.random() * 0.6; // 0.6 to 1.2
+    this.phase = Math.random() * Math.PI * 2;
+    this.forwardSpeed = GameConfig.BASE_SPEED * (1 - SHREDDER.SPEED_JITTER + Math.random() * SHREDDER.SPEED_JITTER * 2);
+
+    this.direction = spawnSide === 'left' ? 1 : -1;
+    this.startX = spawnSide === 'left' ? -this.radius : app.screen.width + this.radius;
+    this.startY = Math.random() * app.screen.height;
+    this.x = this.startX;
+    this.y = this.startY;
+
+    this.sprite = new PIXI.Graphics();
+    this.draw();
+    this.sprite.x = this.x;
+    this.sprite.y = this.y;
+    app.stage.addChild(this.sprite);
+  }
+
+  private draw() {
+    this.sprite.clear();
+    const strokeWidth = Math.max(1.5, this.radius * 0.03);
+    const outer = OUTER.flatMap(p => [p[0] * this.radius, p[1] * this.radius]);
+    this.sprite.poly(outer);
+    this.sprite.stroke({ width: strokeWidth, color: VISUALS.COLORS.WHITE, alpha: VISUALS.ALPHA.FULL });
+    const hub = HUB.flatMap(p => [p[0] * this.radius, p[1] * this.radius]);
+    this.sprite.poly(hub);
+    this.sprite.stroke({ width: strokeWidth, color: VISUALS.COLORS.WHITE, alpha: VISUALS.ALPHA.FULL });
+  }
+
+  update(dt: number): boolean {
+    this.t += dt;
+    const t = this.t;
+    if (this.motionType === 'SINE') {
+      this.x = this.startX + this.direction * this.forwardSpeed * t;
+      this.y = this.startY + this.amplitude * Math.sin(this.omega * t + this.phase);
+    } else if (this.motionType === 'COSINE') {
+      this.x = this.startX + this.direction * this.forwardSpeed * t;
+      this.y = this.startY + this.amplitude * Math.cos(this.omega * t + this.phase);
+    } else {
+      this.x = this.startX + this.direction * this.forwardSpeed * t + 0.3 * this.app.screen.width * Math.sin(this.omega * t + this.phase);
+      this.y = this.startY + this.amplitude * Math.sin(2 * this.omega * t + 0.5 * this.phase);
+    }
+    this.rotation += this.rotationSpeed * dt;
+    this.sprite.x = this.x;
+    this.sprite.y = this.y;
+    this.sprite.rotation = this.rotation;
+
+    return !this.isOffScreen(this.app.screen);
+  }
+
+  isOffScreen(screen: PIXI.Rectangle): boolean {
+    const margin = this.radius * 2;
+    return this.x < -margin || this.x > screen.width + margin || this.y < -margin || this.y > screen.height + margin;
+  }
+
+  destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    EntityDestroyer.destroyEntity({ sprite: this.sprite, app: this.app });
+  }
+}


### PR DESCRIPTION
## Summary
- introduce tri-shuriken Shredder enemy with waveform movement and rotating outline
- configure spawn probability scaling with asteroid count
- award points for shredding small asteroids and document full spec

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: multiple existing tests failing)*

---

# Ticket: "Shredder" tri-shuriken enemy (punishes asteroid spam)

## Summary

Add a special enemy **Shredder** (tri-shuriken outline). It’s **bigger than normal ships** (random up to **3×**), **spins** around its axis, and flies a **waveform path** (sine/cosine or gentle lissajous).
Asteroid interactions:

* **Asteroid smaller than Shredder** → asteroid is **instantly shredded** (laser-hit equivalent).
* **Asteroid equal or larger** → **Shredder explodes**; asteroid survives (optional partial impact damage).

---

## Correct spawn rule

Let `A = asteroidsOnScreen`.

**Piecewise as spec (“> 10” unlocks the boost):**

```
if A ≤ 10:  P = 0.05                // 5%
if A > 10:  P = 0.05 + (A/10)%      // == 0.05 + A/1000
```

**Examples (per spawn check):**

* A=0  → **5%**  (0.05)
* A=10 → **5%**  (0.05)
* A=20 → **7%**  (0.07) ✅
* A=50 → **10%** (0.10)
* A=100 → **15%** (0.15)

*(Optional)* clamp extreme cases: `P_max = 0.25` (25%).

**Cadence:** use the existing enemy spawn tick.
**Concurrency:** `maxConcurrentShredders = 2` (config).

---

## Behavior

* **Scale:** `s ∈ [1.25, 3.0] × normalShipTipRadius`.
* **Spin:** `ω_spin ∈ [0.6, 1.6] rad/s`, random sign.
* **Path (choose at spawn):**

  * `SINE`: `y = y0 + A·sin(ωt + φ)`
  * `COSINE`: `y = y0 + A·cos(ωt + φ)`
  * `LISSAJOUS-lite`: forward drift + mild 1:2 x/y wobble
* **Amplitude:** `A ∈ [0.15, 0.30] × screenHeight`.
* **SpeedX:** reuse normal enemy base speed (± \~20% jitter).
* **Collisions (use radii):** `rS = shredder.radius`, `rA = asteroid.radius`, tolerance `τ = 0.05`.

  * if `rA < rS·(1−τ)` → shred asteroid (instant kill, sparks FX, small score).
  * if `rA > rS·(1+τ)` → Shredder explodes (asteroid persists; optional impact damage).
  * else (≈equal) → both destroyed.

---

## Inline assets (no attachments)

### A) SVG (outline-only)

```svg
<svg xmlns="http://www.w3.org/2000/svg" viewBox="-122 -122 244 244" width="244" height="244">
  <!-- outer outline -->
  <polyline points="-39.0,67.5 0.0,110.0 39.0,67.5 39.0,-67.5 0.0,-110.0 -39.0,-67.5 -97.5,0.0 -90.4,15.6 -78.4,27.6 -67.5,39.0 -39.0,67.5"
            fill="none" stroke="#000" stroke-width="2" stroke-linejoin="miter" stroke-linecap="square"/>
  <!-- inner hub (triangle) -->
  <polyline points="0.0,18.0 15.6,-9.0 -15.6,-9.0 0.0,18.0"
            fill="none" stroke="#000" stroke-width="2" stroke-linejoin="miter" stroke-linecap="square"/>
</svg>
```

*Note:* This SVG’s coordinates are based on a tip radius of **110** units. The normalized points below divide by 110, so the **furthest tip = 1.0**.

### B) Normalized vector points (furthest tip = 1.0)

```js
// OUTER polyline (closed by repeating the first point at the end)
const OUTER = [
  [-0.3545,  0.6136], [ 0.0000,  1.0000], [ 0.3545,  0.6136],
  [ 0.3545, -0.6136], [ 0.0000, -1.0000], [-0.3545, -0.6136],
  [-0.8864,  0.0000], [-0.8218,  0.1418], [-0.7127,  0.2509],
  [-0.6136,  0.3545], [-0.3545,  0.6136]
];

// HUB triangle (closed by repeating the first point)
const HUB = [
  [ 0.0000,  0.1636], [ 0.1418, -0.0818],
  [-0.1418, -0.0818], [ 0.0000,  0.1636]
];
```

✔️ Checks: `67.5/110=0.6136`, `39/110=0.3545`, `97.5/110=0.8864`, `18/110=0.1636`, `15.6/110=0.1418`, `9/110=0.0818`.

---

## Pseudocode only (framework-agnostic)

> Replace identifiers/types with your engine’s. This is **dummy code** to express intent — **not** drop-in.

### Spawner (called on your existing spawn tick)

```
function maybeSpawnShredder(world):
    A = world.countOnscreen("asteroid")
    if A <= 10:
        P = 0.05                       // 5%
    else:
        P = 0.05 + (A / 1000)          // 5% + (A/10)%

    if CONFIG.clampEnabled:
        P = min(P, CONFIG.maxSpawnProb)    // e.g., 0.25

    if world.countOnscreen("Shredder") >= CONFIG.maxConcurrent:
        return

    if random() < P:
        side = randomChoice("left","right")
        world.spawn( Shredder(side) )
```

### Shredder entity (reuses base enemy lifecycle)

```
class Shredder extends EnemyBase:
    init(spawnSide):
        scale = rand(1.25, 3.0)
        tipRadius = NORMAL_SHIP_TIP_RADIUS * scale
        rotationSpeed = rand(0.6, 1.6) * randomSign()

        // choose motion
        motionType = randomChoice(SINE, COSINE, LISSAJOUS_LITE)
        amplitude = rand(0.15, 0.30) * SCREEN_H
        omega = rand(0.6, 1.2)
        phase = rand(0, 2π)
        forwardSpeedX = BASE_ENEMY_SPEED_X * rand(0.9, 1.2)
        setStartPositionBySide(spawnSide)

    update(dt):
        // forward drift + waveform
        t += dt
        if motionType == SINE:
            x = x0 + dir * forwardSpeedX * t
            y = y0 + amplitude * sin(omega * t + phase)
        else if motionType == COSINE:
            x = x0 + dir * forwardSpeedX * t
            y = y0 + amplitude * cos(omega * t + phase)
        else: // LISSAJOUS_LITE
            x = x0 + dir * forwardSpeedX * t + 0.30*SCREEN_W * sin(1*omega*t + phase)
            y = y0 + amplitude *        sin(2*omega*t + 0.5*phase)

        rotation += rotationSpeed * dt
        applyCommonEnemyLifetimeCulling()

    render(renderer):
        // Outline look; if your engine is sprite/mesh-based, draw equivalent
        renderer.drawTriShurikenOutline(position, tipRadius, rotation,
                                        strokeWidth = max(1.5, tipRadius * 0.03))

    onCollision(other):
        if other.type != "asteroid":
            return handleWithBaseEnemyRules(other)

        rS = tipRadius
        rA = other.radius
        τ  = 0.05   // 5% tolerance

        if rA < rS * (1 - τ):
            other.destroyAsLaserHit()
            fx("shred_sparks", other.pos)
            score.add(+10)
        else if rA > rS * (1 + τ):
            other.applyImpactDamage(frac = 0.35)   // optional
            self.explode()
            fx("metal_burst", self.pos)
        else:
            other.destroy()
            self.explode()
```

---

## Acceptance criteria

* **Math:** For `A=20`, per-check probability is **7%** (0.07). For `A=50`, **10%**. For `A=100`, **15%**.
* **Spawn system:** Uses existing spawn cadence; never exceeds `maxConcurrentShredders`.
* **Movement:** Clear sine/cosine/lissajous-lite motion; amplitude in **15–30%** of screen height.
* **Visuals:** Outline tri-shuriken scales **1.25×–3×**; crisp miter joins; continuous rotation.
* **Collisions:** Smaller asteroid shredded; larger asteroid destroys Shredder; near-equal → both destroyed.
* **DRY:** Reuse base enemy lifecycle (pooling, culling, explosion, scoring hooks).

---

## Test plan

1. **Probability table:** A={0,10,20,50,100} → P={0.05, 0.05, 0.07, 0.10, 0.15}.
2. **Monte-Carlo sanity:** simulate 10k spawn ticks at A=20 → observed spawn ≈ 7% ± noise.
3. **Motion & spin:** logs show amplitude within 0.15–0.30H; rotation speed within range and random sign.
4. **Collision branches:** verify small, large, near-equal outcomes and correct FX/score hooks.
5. **Concurrency:** never exceed `maxConcurrentShredders` even under A=200 (stress).


------
https://chatgpt.com/codex/tasks/task_b_68a0924889bc8324bd54126911dc7c46